### PR TITLE
fix file name for downloaded file

### DIFF
--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -17,7 +17,10 @@ class RSSEntity():
 class RSSEntitySimpleName(RSSEntity):
 
     def to_file_name(self) -> str:
-        return self.link.rpartition('/')[-1].lower()
+        filename = self.link.rpartition('/')[-1].lower()
+        if filename.find("?") > 0:
+            filename = filename.rpartition('?')[0]
+        return filename
 
 @dataclass
 class RSSEntityWithDate(RSSEntity):


### PR DESCRIPTION
If the URL of the file to download has any arguments ("?source=feed"
or similar), the local file cannot be created and the file cannot
be downloaded.
These arguments should not be part of the local file name.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>