### PR TITLE
Fix global option resolution and zero-valued CLI arguments

### DIFF
--- a/e2e/test_global_option_resolution.py
+++ b/e2e/test_global_option_resolution.py
@@ -120,8 +120,6 @@ def test_cli_zero_downloads_limit_overrides_configuration(
     )
 
     config_path = podcast_downloader.script_directory / DEFAULT_CONFIG_NAME
-    podcast_downloader.run(
-        ["--config", str(config_path), "--downloads_limit", "0"]
-    )
+    podcast_downloader.run(["--config", str(config_path), "--downloads_limit", "0"])
 
     podcast_directory.is_containing_only([])

--- a/e2e/test_global_option_resolution.py
+++ b/e2e/test_global_option_resolution.py
@@ -6,6 +6,7 @@ from e2e.fixures import (
     FeedBuilder,
     PodcastDirectory,
     PodcastDownloaderRunner,
+    download_destination_directory,
     feed,
     use_config,
     podcast_directory,
@@ -94,7 +95,8 @@ def test_configuration_global_download_delay_option(
     podcast_downloader.run()
 
     podcast_directory.is_containing_only([name.lower() for name in files_to_download])
-    assert podcast_downloader.is_containing("The download is sleeping (1 second)")
+    assert podcast_downloader.is_containing("The download is sleeping (")
+    assert podcast_downloader.is_highlighted_in_outcome("1")
 
 
 def test_cli_zero_downloads_limit_overrides_configuration(

--- a/e2e/test_global_option_resolution.py
+++ b/e2e/test_global_option_resolution.py
@@ -1,0 +1,125 @@
+from itertools import chain
+from typing import Callable, Dict, List
+
+from e2e.fixures import (
+    DEFAULT_CONFIG_NAME,
+    FeedBuilder,
+    PodcastDirectory,
+    PodcastDownloaderRunner,
+    feed,
+    use_config,
+    podcast_directory,
+    podcast_downloader,
+)
+from e2e.random import call_n_times, generate_random_mp3_file
+
+
+def test_configuration_global_fill_up_gaps_option(
+    feed: FeedBuilder,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: Callable[[List[str]], PodcastDownloaderRunner],
+    podcast_directory: PodcastDirectory,
+):
+    files_downloaded_and_removed = call_n_times(generate_random_mp3_file)
+    downloaded_files_before_gap = call_n_times(generate_random_mp3_file)
+    files_in_the_gap = call_n_times(generate_random_mp3_file)
+    downloaded_files_after_gap = call_n_times(generate_random_mp3_file)
+    files_to_download = call_n_times(generate_random_mp3_file)
+
+    for file_name in chain(
+        files_downloaded_and_removed,
+        downloaded_files_before_gap,
+        files_in_the_gap,
+        downloaded_files_after_gap,
+        files_to_download,
+    ):
+        feed.add_entry(file_name)
+
+    for file_name in chain(
+        downloaded_files_before_gap,
+        downloaded_files_after_gap,
+    ):
+        podcast_directory.add_file(file_name)
+
+    use_config(
+        {
+            "fill_up_gaps": True,
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": feed.get_feed_url(),
+                }
+            ],
+        }
+    )
+
+    podcast_downloader.run()
+
+    podcast_directory.is_containing_only(
+        [
+            file_name.lower()
+            for file_name in chain(
+                downloaded_files_before_gap,
+                files_in_the_gap,
+                downloaded_files_after_gap,
+                files_to_download,
+            )
+        ]
+    )
+
+
+def test_configuration_global_download_delay_option(
+    feed: FeedBuilder,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: Callable[[List[str]], PodcastDownloaderRunner],
+    podcast_directory: PodcastDirectory,
+):
+    files_to_download = [generate_random_mp3_file(), generate_random_mp3_file()]
+    for file_name in files_to_download:
+        feed.add_entry(file_name=file_name)
+
+    use_config(
+        {
+            "if_directory_empty": "download_all_from_feed",
+            "download_delay": 1,
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": feed.get_feed_url(),
+                }
+            ],
+        }
+    )
+
+    podcast_downloader.run()
+
+    podcast_directory.is_containing_only([name.lower() for name in files_to_download])
+    assert podcast_downloader.is_containing("The download is sleeping (1 second)")
+
+
+def test_cli_zero_downloads_limit_overrides_configuration(
+    feed: FeedBuilder,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: PodcastDownloaderRunner,
+    podcast_directory: PodcastDirectory,
+):
+    feed.add_entry(file_name=generate_random_mp3_file())
+
+    use_config(
+        {
+            "if_directory_empty": "download_all_from_feed",
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": feed.get_feed_url(),
+                }
+            ],
+        }
+    )
+
+    config_path = podcast_downloader.script_directory / DEFAULT_CONFIG_NAME
+    podcast_downloader.run(
+        ["--config", str(config_path), "--downloads_limit", "0"]
+    )
+
+    podcast_directory.is_containing_only([])

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -352,7 +352,7 @@ if __name__ == "__main__":
                     continue
 
                 if DOWNLOADS_LIMITS == 0:
-                    continue
+                    break
 
                 if rss_download_delay > 0 and not first_element:
                     logger.info(

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -265,12 +265,12 @@ if __name__ == "__main__":
             rss_source.get(configuration.CONFIG_HTTP_HEADER, {}),
         )
         rss_fill_up_gaps = rss_source.get(
+            configuration.CONFIG_FILL_UP_GAPS,
             CONFIGURATION[configuration.CONFIG_FILL_UP_GAPS],
-            rss_source.get(configuration.CONFIG_FILL_UP_GAPS, False),
         )
         rss_download_delay = rss_source.get(
+            configuration.CONFIG_DOWNLOAD_DELAY,
             CONFIGURATION[configuration.CONFIG_DOWNLOAD_DELAY],
-            rss_source.get(configuration.CONFIG_DOWNLOAD_DELAY, 0),
         )
 
         if rss_disable:
@@ -347,20 +347,18 @@ if __name__ == "__main__":
 
             first_element = True
             for rss_entry in reversed(missing_files_links):
-                if rss_download_delay > 0:
-                    if not first_element:
-                        logger.info(
-                            "The download is sleeping (%d second)", rss_download_delay
-                        )
-                        time.sleep(rss_download_delay)
-                        first_element = False
-
                 wanted_podcast_file_name = to_name_function(rss_entry)
                 if wanted_podcast_file_name in downloaded_files:
                     continue
 
                 if DOWNLOADS_LIMITS == 0:
                     continue
+
+                if rss_download_delay > 0 and not first_element:
+                    logger.info(
+                        "The download is sleeping (%d second)", rss_download_delay
+                    )
+                    time.sleep(rss_download_delay)
 
                 if len(wanted_podcast_file_name) > file_length_limit:
                     logger.info(
@@ -377,6 +375,7 @@ if __name__ == "__main__":
 
                 download_podcast(rss_source_path, rss_entry)
                 DOWNLOADS_LIMITS -= 1
+                first_element = False
         else:
             logger.info("%s: Nothing new", rss_source_name)
 

--- a/podcast_downloader/parameters.py
+++ b/podcast_downloader/parameters.py
@@ -22,4 +22,8 @@ def load_configuration_file(file_path: str) -> dict:
 
 
 def parse_argv(parser: ArgumentParser, args=None):
-    return {key: value for key, value in vars(parser.parse_args(args)).items() if value}
+    return {
+        key: value
+        for key, value in vars(parser.parse_args(args)).items()
+        if value is not None
+    }

--- a/tests/parameters_test.py
+++ b/tests/parameters_test.py
@@ -1,0 +1,24 @@
+import unittest
+
+from podcast_downloader.__main__ import build_parser
+from podcast_downloader.parameters import parse_argv
+
+
+class ParseArgvTest(unittest.TestCase):
+    def test_preserves_zero_downloads_limit(self):
+        parameters = parse_argv(build_parser(), ["--downloads_limit", "0"])
+
+        self.assertEqual(0, parameters["downloads_limit"])
+
+    def test_preserves_zero_download_delay(self):
+        parameters = parse_argv(build_parser(), ["--download_delay", "0"])
+
+        self.assertEqual(0, parameters["download_delay"])
+
+    def test_omits_parameters_not_provided(self):
+        parameters = parse_argv(build_parser(), [])
+
+        self.assertNotIn("downloads_limit", parameters)
+        self.assertNotIn("download_delay", parameters)
+        self.assertNotIn("config", parameters)
+        self.assertNotIn("if_directory_empty", parameters)


### PR DESCRIPTION
While testing the global options I noticed that `fill_up_gaps` and `download_delay` were using the configured value as the key in `rss_source.get()`. Because of that, podcasts were not inheriting those global values.

`download_delay` also never moved past the first element, so the sleep branch was never reached.

I also changed `parse_argv()` to keep explicit zero values instead of filtering them out. This makes cases like `--downloads_limit 0` work as an override instead of falling back to the config/default value.

I added regression tests for:

* global `fill_up_gaps`
* global `download_delay`
* zero-valued CLI arguments
* `--downloads_limit 0` overriding the configuration

The changes are limited to option resolution and the delay loop.
