### PR TITLE
Fix calendar-based empty-directory filters

### DIFF
--- a/e2e/test_invalid_configuration_isolation.py
+++ b/e2e/test_invalid_configuration_isolation.py
@@ -1,0 +1,52 @@
+from typing import Callable, Dict
+
+from e2e.fixures import (
+    MultipleFeedBuilder,
+    MultiplePodcastDirectory,
+    PodcastDownloaderRunner,
+    feed_builder_manager,
+    podcast_directory_manager,
+    podcast_downloader,
+    use_config,
+)
+from e2e.random import generate_random_mp3_file
+
+
+def test_missing_last_run_marker_only_skips_affected_podcast(
+    feed_builder_manager: MultipleFeedBuilder,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: PodcastDownloaderRunner,
+    podcast_directory_manager: MultiplePodcastDirectory,
+):
+    second_podcast_file = generate_random_mp3_file()
+
+    feed_builder_manager.first_feed.add_random_entries()
+    feed_builder_manager.second_feed.add_entry(file_name=second_podcast_file)
+
+    use_config(
+        {
+            "podcasts": [
+                {
+                    "name": "invalid",
+                    "if_directory_empty": "download_since_last_run",
+                    "path": podcast_directory_manager.get_first_directory(),
+                    "rss_link": feed_builder_manager.first_feed.get_feed_url(),
+                },
+                {
+                    "name": "valid",
+                    "if_directory_empty": "download_last",
+                    "path": podcast_directory_manager.get_second_directory(),
+                    "rss_link": feed_builder_manager.second_feed.get_feed_url(),
+                },
+            ]
+        }
+    )
+
+    runner = podcast_downloader.run()
+
+    assert runner.is_containing("Invalid if_directory_empty value")
+    assert runner.is_highlighted_in_outcome("download_since_last_run")
+    assert list(podcast_directory_manager.get_first_directory_files()) == []
+    assert {
+        file.name for file in podcast_directory_manager.get_second_directory_files()
+    } == {second_podcast_file.lower()}

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -293,9 +293,18 @@ if __name__ == "__main__":
             rss_file_name_template_value, rss_source
         )
 
-        on_empty_directory = configuration_to_function_on_empty_directory(
-            rss_on_empty_directory, LAST_RUN_DATETIME
-        )
+        try:
+            on_empty_directory = configuration_to_function_on_empty_directory(
+                rss_on_empty_directory, LAST_RUN_DATETIME
+            )
+        except (ValueError, TypeError) as error:
+            logger.error(
+                'Invalid if_directory_empty value "%s" for "%s": %s',
+                rss_on_empty_directory,
+                rss_source_name or rss_source_link,
+                error,
+            )
+            continue
 
         downloaded_files = list(
             get_downloaded_files(

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -130,7 +130,7 @@ def configuration_to_function_on_empty_directory(
 
         return only_entities_from_date(get_label_to_date(day_label)(local_time))
 
-    raise Exception(f"The value the '{configuration_value}' is not recognizable")
+    raise ValueError(f"The value the '{configuration_value}' is not recognizable")
 
 
 def is_windows_running():

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -130,7 +130,7 @@ def configuration_to_function_on_empty_directory(
 
         return only_entities_from_date(get_label_to_date(day_label)(local_time))
 
-    raise ValueError(f"The value the '{configuration_value}' is not recognizable")
+    raise ValueError(f"Unrecognized if_directory_empty value '{configuration_value}'")
 
 
 def is_windows_running():

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -110,7 +110,7 @@ def configuration_to_function_on_empty_directory(
         logger.error(
             'The "download_since_last_run" require setup the "last_run_mark_file_path"'
         )
-        raise Exception("Missing the last run mark file")
+        raise ValueError("Missing the last run mark file")
 
     local_time = time.localtime()
 

--- a/podcast_downloader/configuration.py
+++ b/podcast_downloader/configuration.py
@@ -116,4 +116,4 @@ def parse_day_label(raw_label: str) -> Union[str, int]:
     if capitalize_raw_label in short_weekdays:
         return WEEK_DAYS[short_weekdays.index(capitalize_raw_label)]
 
-    raise Exception(f"Cannot read weekday name '{raw_label}'")
+    raise ValueError(f"Cannot read weekday name '{raw_label}'")

--- a/podcast_downloader/configuration.py
+++ b/podcast_downloader/configuration.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import List, Tuple, Union
 from datetime import datetime, timedelta
+import re
 import time
 
 SECONDS_IN_DAY = 24 * 60 * 60
@@ -103,17 +104,9 @@ def parse_day_label(raw_label: str) -> Union[str, int]:
     if raw_label.isnumeric():
         return validate_month_day(int(raw_label))
 
-    if raw_label == "1st":
-        return 1
-
-    if raw_label == "2nd":
-        return 2
-
-    if raw_label == "3rd":
-        return 3
-
-    if raw_label[-2:] == "th":
-        return validate_month_day(int(raw_label[:-2]))
+    ordinal_match = re.fullmatch(r"(\d+)(st|nd|rd|th)", raw_label)
+    if ordinal_match:
+        return validate_month_day(int(ordinal_match.group(1)))
 
     capitalize_raw_label = raw_label.capitalize()
     if capitalize_raw_label in WEEK_DAYS:

--- a/podcast_downloader/configuration.py
+++ b/podcast_downloader/configuration.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 from datetime import datetime, timedelta
 import re
 import time
@@ -38,7 +38,7 @@ MAX_MONTH_DAY = 28
 
 def configuration_verification(config: dict) -> Tuple[bool, Optional[str]]:
     for podcast in config[CONFIG_PODCASTS]:
-        podcast_name = podcast.get(CONFIG_PODCASTS_NAME, "<unnamed>")
+        podcast_name = podcast.get(CONFIG_PODCASTS_NAME) or "<unnamed>"
 
         if CONFIG_PODCASTS_PATH not in podcast:
             return (

--- a/podcast_downloader/configuration.py
+++ b/podcast_downloader/configuration.py
@@ -31,19 +31,24 @@ WEEK_DAYS = (
     "Sunday",
 )
 
+MIN_MONTH_DAY = 1
+MAX_MONTH_DAY = 28
+
 
 def configuration_verification(config: dict) -> Tuple[bool, List[str]]:
     for podcast in config[CONFIG_PODCASTS]:
-        if not CONFIG_PODCASTS_PATH in podcast:
+        podcast_name = podcast.get(CONFIG_PODCASTS_NAME, "<unnamed>")
+
+        if CONFIG_PODCASTS_PATH not in podcast:
             return (
                 False,
-                f"There is no path for podcast {podcast[CONFIG_PODCASTS_NAME]}",
+                f"There is no path for podcast {podcast_name}",
             )
 
-        if not CONFIG_PODCASTS_RSS_LINK in podcast:
+        if CONFIG_PODCASTS_RSS_LINK not in podcast:
             return (
                 False,
-                f"There is no RSS link for podcast {podcast[CONFIG_PODCASTS_NAME]}",
+                f"There is no RSS link for podcast {podcast_name}",
             )
 
     return True, None
@@ -53,11 +58,19 @@ def get_n_age_date(day_number: int, from_date: time.struct_time) -> time.struct_
     return time.localtime(time.mktime(from_date) - day_number * SECONDS_IN_DAY)
 
 
+def validate_month_day(day: int) -> int:
+    if day < MIN_MONTH_DAY or day > MAX_MONTH_DAY:
+        raise ValueError(
+            f"Day number must be between {MIN_MONTH_DAY} and {MAX_MONTH_DAY}"
+        )
+    return day
+
+
 def get_label_to_date(day_label: Union[str, int]) -> partial:
     if day_label in WEEK_DAYS:
         return partial(get_week_day, day_label)
 
-    return partial(get_nth_day, int(day_label))
+    return partial(get_nth_day, validate_month_day(int(day_label)))
 
 
 def get_week_day(weekday_label: str, from_date: time.struct_time) -> time.struct_time:
@@ -74,21 +87,21 @@ def get_week_day(weekday_label: str, from_date: time.struct_time) -> time.struct
 
 
 def get_nth_day(day: int, from_date: time.struct_time) -> time.struct_time:
+    day = validate_month_day(day)
     from_datetime = datetime(*from_date[:6])
 
-    day_difference = from_date[2] - day
-    datetime_result = (
-        from_datetime - timedelta(days=day_difference - 1)
-        if day_difference > 0
-        else (from_datetime.replace(day=1) - timedelta(days=28)).replace(day=day + 1)
-    )
+    if from_datetime.day > day:
+        selected_day = from_datetime.replace(day=day)
+    else:
+        previous_month_last_day = from_datetime.replace(day=1) - timedelta(days=1)
+        selected_day = previous_month_last_day.replace(day=day)
 
-    return datetime_result.timetuple()
+    return (selected_day + timedelta(days=1)).timetuple()
 
 
 def parse_day_label(raw_label: str) -> Union[str, int]:
     if raw_label.isnumeric():
-        return int(raw_label)
+        return validate_month_day(int(raw_label))
 
     if raw_label == "1st":
         return 1
@@ -100,7 +113,7 @@ def parse_day_label(raw_label: str) -> Union[str, int]:
         return 3
 
     if raw_label[-2:] == "th":
-        return int(raw_label[:-2])
+        return validate_month_day(int(raw_label[:-2]))
 
     capitalize_raw_label = raw_label.capitalize()
     if capitalize_raw_label in WEEK_DAYS:

--- a/podcast_downloader/configuration.py
+++ b/podcast_downloader/configuration.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 from datetime import datetime, timedelta
 import re
 import time
@@ -36,7 +36,7 @@ MIN_MONTH_DAY = 1
 MAX_MONTH_DAY = 28
 
 
-def configuration_verification(config: dict) -> Tuple[bool, List[str]]:
+def configuration_verification(config: dict) -> Tuple[bool, Optional[str]]:
     for podcast in config[CONFIG_PODCASTS]:
         podcast_name = podcast.get(CONFIG_PODCASTS_NAME, "<unnamed>")
 
@@ -116,4 +116,4 @@ def parse_day_label(raw_label: str) -> Union[str, int]:
     if capitalize_raw_label in short_weekdays:
         return WEEK_DAYS[short_weekdays.index(capitalize_raw_label)]
 
-    raise ValueError(f"Cannot read weekday name '{raw_label}'")
+    raise ValueError(f"Cannot read day or weekday label '{raw_label}'")

--- a/tests/calendar_validation_test.py
+++ b/tests/calendar_validation_test.py
@@ -21,6 +21,17 @@ class CalendarValidationTest(unittest.TestCase):
 
         self.assertEqual(get_nth_day(28, current_date), expected_date)
 
+    def test_same_day_uses_previous_month(self):
+        current_date = strptime("21.08.2026", "%d.%m.%Y")
+        expected_date = strptime("22.07.2026", "%d.%m.%Y")
+
+        self.assertEqual(get_nth_day(21, current_date), expected_date)
+
+    def test_ordinal_day_labels_are_supported(self):
+        for value, expected in (("21st", 21), ("22nd", 22), ("23rd", 23)):
+            with self.subTest(value=value):
+                self.assertEqual(expected, parse_day_label(value))
+
     def test_day_labels_outside_documented_range_are_rejected(self):
         for value in ("0", "29", "31", "29th", "31st"):
             with self.subTest(value=value):

--- a/tests/calendar_validation_test.py
+++ b/tests/calendar_validation_test.py
@@ -47,6 +47,22 @@ class CalendarValidationTest(unittest.TestCase):
         self.assertIn("<unnamed>", error)
         self.assertIn("path", error)
 
+    def test_null_name_uses_unnamed_fallback_in_configuration_validation(self):
+        valid, error = configuration_verification(
+            {
+                "podcasts": [
+                    {
+                        "name": None,
+                        "rss_link": "https://example.com/feed.xml",
+                    }
+                ]
+            }
+        )
+
+        self.assertFalse(valid)
+        self.assertIn("<unnamed>", error)
+        self.assertNotIn("podcast None", error)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/calendar_validation_test.py
+++ b/tests/calendar_validation_test.py
@@ -1,0 +1,41 @@
+from time import strptime
+import unittest
+
+from podcast_downloader.configuration import (
+    configuration_verification,
+    get_nth_day,
+    parse_day_label,
+)
+
+
+class CalendarValidationTest(unittest.TestCase):
+    def test_28th_after_non_leap_february_rolls_to_march(self):
+        current_date = strptime("04.03.2023", "%d.%m.%Y")
+        expected_date = strptime("01.03.2023", "%d.%m.%Y")
+
+        self.assertEqual(get_nth_day(28, current_date), expected_date)
+
+    def test_28th_after_leap_february_returns_february_29(self):
+        current_date = strptime("04.03.2024", "%d.%m.%Y")
+        expected_date = strptime("29.02.2024", "%d.%m.%Y")
+
+        self.assertEqual(get_nth_day(28, current_date), expected_date)
+
+    def test_day_labels_outside_documented_range_are_rejected(self):
+        for value in ("0", "29", "31", "29th", "31st"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    parse_day_label(value)
+
+    def test_missing_name_does_not_crash_configuration_validation(self):
+        valid, error = configuration_verification(
+            {"podcasts": [{"rss_link": "https://example.com/feed.xml"}]}
+        )
+
+        self.assertFalse(valid)
+        self.assertIn("<unnamed>", error)
+        self.assertIn("path", error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/get_all_entries_from_th_day_test.py
+++ b/tests/get_all_entries_from_th_day_test.py
@@ -38,7 +38,7 @@ class TestParseDayLabel(unittest.TestCase):
             result = get_label_to_date(week_day)
             self.assertEqual(result.func, get_week_day)
 
-        for day_number in range(1, 32):
+        for day_number in range(1, 29):
             result = get_label_to_date(day_number)
             self.assertEqual(result.func, get_nth_day)
 


### PR DESCRIPTION
While checking the monthly `download_from_<day>` options I found that the date calculation could try to construct an invalid February date when using values such as `download_from_28th`.

This changes the monthly calculation to select the requested day first and then advance one day, preserving the existing filter semantics while allowing normal month rollover.

It also:

- accepts ordinal forms such as `21st`, `22nd` and `23rd`;
- keeps the documented monthly range at 1–28;
- reports invalid `if_directory_empty` values for that podcast instead of aborting the rest of the run.

Regression tests cover non-leap and leap February, ordinal labels, the same-day case, out-of-range values, and invalid configuration isolation.