### PR TITLE
Handle failed and malformed RSS feeds

### DIFF
--- a/e2e/test_podcast_http_headers.py
+++ b/e2e/test_podcast_http_headers.py
@@ -1,0 +1,53 @@
+from typing import Callable, Dict
+
+from pytest_httpserver import HTTPServer
+
+from e2e.fixures import (
+    FeedBuilder,
+    PodcastDirectory,
+    PodcastDownloaderRunner,
+    download_destination_directory,
+    feed,
+    podcast_directory,
+    podcast_downloader,
+    use_config,
+)
+from e2e.random import generate_random_string
+
+
+def test_explicit_empty_podcast_headers_do_not_inherit_global_headers(
+    feed: FeedBuilder,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: PodcastDownloaderRunner,
+    podcast_directory: PodcastDirectory,
+    httpserver: HTTPServer,
+):
+    global_header_name = "X-Podcast-Downloader-Test"
+    global_header_value = generate_random_string()
+
+    feed.add_random_entries()
+    rss_link = feed.get_feed_url()
+
+    use_config(
+        {
+            "http_headers": {global_header_name: global_header_value},
+            "podcasts": [
+                {
+                    "http_headers": {},
+                    "path": podcast_directory.path(),
+                    "rss_link": rss_link,
+                }
+            ],
+        }
+    )
+
+    podcast_downloader.run()
+
+    feed_requests = [
+        log[0]
+        for log in httpserver.log
+        if log[0].path == FeedBuilder.FEED_RSS_FILE_NAME
+    ]
+
+    assert feed_requests
+    assert all(request.headers.get(global_header_name) is None for request in feed_requests)

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":
             logger.info('Skipping the "%s"', rss_source_name or rss_source_link)
             continue
 
-        feed = load_feed(rss_source_link)
+        feed = load_feed(rss_source_link, rss_https_header)
         if feed.bozo and len(feed.entries) == 0:
             logger.error(
                 f"Error while checking the link: '{rss_source_link}': {feed['bozo_exception']}"
@@ -285,7 +285,7 @@ if __name__ == "__main__":
             continue
 
         if not rss_source_name:
-            rss_source_name = get_feed_title_from_feed(feed)
+            rss_source_name = get_feed_title_from_feed(feed) or rss_source_link
 
         logger.info('Checking "%s"', rss_source_name)
 

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -260,9 +260,15 @@ if __name__ == "__main__":
             configuration.CONFIG_PODCAST_EXTENSIONS,
             CONFIGURATION[configuration.CONFIG_PODCAST_EXTENSIONS],
         )
-        rss_https_header = merge_parameters_collection(
-            CONFIGURATION[configuration.CONFIG_HTTP_HEADER],
-            rss_source.get(configuration.CONFIG_HTTP_HEADER, {}),
+        rss_source_http_headers = rss_source.get(configuration.CONFIG_HTTP_HEADER)
+        rss_https_header = (
+            {}
+            if configuration.CONFIG_HTTP_HEADER in rss_source
+            and rss_source_http_headers == {}
+            else merge_parameters_collection(
+                CONFIGURATION[configuration.CONFIG_HTTP_HEADER],
+                rss_source_http_headers or {},
+            )
         )
         rss_fill_up_gaps = rss_source.get(
             CONFIGURATION[configuration.CONFIG_FILL_UP_GAPS],

--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -143,7 +143,15 @@ def flatten_rss_links_data(
 
             entities.append(RSSEntity(published_date, title, link_type, href))
 
-    if len(entities) > 1 and entities[0].published_date < entities[-1].published_date:
+    is_ascending = all(
+        first.published_date <= second.published_date
+        for first, second in zip(entities, entities[1:])
+    )
+    if (
+        len(entities) > 1
+        and is_ascending
+        and entities[0].published_date < entities[-1].published_date
+    ):
         entities.reverse()
 
     yield from entities

--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -4,7 +4,7 @@ import urllib.request
 from dataclasses import dataclass
 from functools import partial
 from itertools import takewhile, islice
-from typing import Callable, Generator, Iterator, List
+from typing import Callable, Dict, Generator, Iterator, List
 import unicodedata
 import feedparser
 from urllib.parse import urlsplit, unquote
@@ -91,11 +91,16 @@ def limit_file_name(maximum_length: int, file_name: str) -> str:
     )
 
 
-def load_feed(rss_link: str) -> feedparser.FeedParserDict:
+def load_feed(
+    rss_link: str, headers: Dict[str, str] = None
+) -> feedparser.FeedParserDict:
+    if urlsplit(rss_link).scheme not in ("http", "https"):
+        return feedparser.parse(rss_link)
+
+    request_headers = headers or {"User-Agent": "podcast-downloader"}
+
     try:
-        request = urllib.request.Request(
-            rss_link, headers={"User-Agent": "podcast-downloader"}
-        )
+        request = urllib.request.Request(rss_link, headers=request_headers)
         with urllib.request.urlopen(request, timeout=FEED_TIMEOUT_SECONDS) as response:
             return feedparser.parse(response)
     except Exception as error:
@@ -138,7 +143,10 @@ def flatten_rss_links_data(
 
             entities.append(RSSEntity(published_date, title, link_type, href))
 
-    yield from sorted(entities, key=lambda entity: entity.published_date, reverse=True)
+    if len(entities) > 1 and entities[0].published_date < entities[-1].published_date:
+        entities.reverse()
+
+    yield from entities
 
 
 def build_only_allowed_filter_for_link_data(

--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -1,5 +1,6 @@
 import re
 import time
+import urllib.request
 from dataclasses import dataclass
 from functools import partial
 from itertools import takewhile, islice
@@ -10,6 +11,7 @@ from urllib.parse import urlsplit, unquote
 
 
 FILE_NAME_CHARACTER_LIMIT = 255
+FEED_TIMEOUT_SECONDS = 30
 
 
 @dataclass
@@ -90,11 +92,23 @@ def limit_file_name(maximum_length: int, file_name: str) -> str:
 
 
 def load_feed(rss_link: str) -> feedparser.FeedParserDict:
-    return feedparser.parse(rss_link)
+    try:
+        request = urllib.request.Request(
+            rss_link, headers={"User-Agent": "podcast-downloader"}
+        )
+        with urllib.request.urlopen(request, timeout=FEED_TIMEOUT_SECONDS) as response:
+            return feedparser.parse(response)
+    except Exception as error:
+        return feedparser.FeedParserDict(
+            feed=feedparser.FeedParserDict(),
+            entries=[],
+            bozo=True,
+            bozo_exception=error,
+        )
 
 
 def get_feed_title_from_feed(feedParser: feedparser.FeedParserDict) -> str:
-    return feedParser.feed.title
+    return feedParser.feed.get("title", "")
 
 
 def get_raw_rss_entries_from_feed(
@@ -106,16 +120,21 @@ def get_raw_rss_entries_from_feed(
 def flatten_rss_links_data(
     source: Generator[feedparser.FeedParserDict, None, None]
 ) -> Generator[RSSEntity, None, None]:
-    return (
-        RSSEntity(
-            rss_entry.published_parsed,
-            rss_entry.title,
-            link.type,
-            link.get("href", None),
+    for rss_entry in source:
+        published_date = rss_entry.get("published_parsed") or rss_entry.get(
+            "updated_parsed"
         )
-        for rss_entry in source
-        for link in rss_entry.links
-    )
+        if published_date is None:
+            continue
+
+        title = rss_entry.get("title", "")
+        for link in rss_entry.get("links", []):
+            link_type = link.get("type")
+            href = link.get("href")
+            if not link_type or not href:
+                continue
+
+            yield RSSEntity(published_date, title, link_type, href)
 
 
 def build_only_allowed_filter_for_link_data(

--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -120,6 +120,8 @@ def get_raw_rss_entries_from_feed(
 def flatten_rss_links_data(
     source: Generator[feedparser.FeedParserDict, None, None]
 ) -> Generator[RSSEntity, None, None]:
+    entities = []
+
     for rss_entry in source:
         published_date = rss_entry.get("published_parsed") or rss_entry.get(
             "updated_parsed"
@@ -134,7 +136,9 @@ def flatten_rss_links_data(
             if not link_type or not href:
                 continue
 
-            yield RSSEntity(published_date, title, link_type, href)
+            entities.append(RSSEntity(published_date, title, link_type, href))
+
+    yield from sorted(entities, key=lambda entity: entity.published_date, reverse=True)
 
 
 def build_only_allowed_filter_for_link_data(

--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -4,7 +4,7 @@ import urllib.request
 from dataclasses import dataclass
 from functools import partial
 from itertools import takewhile, islice
-from typing import Callable, Dict, Generator, Iterator, List
+from typing import Callable, Dict, Generator, Iterator, List, Optional
 import unicodedata
 import feedparser
 from urllib.parse import urlsplit, unquote
@@ -92,12 +92,14 @@ def limit_file_name(maximum_length: int, file_name: str) -> str:
 
 
 def load_feed(
-    rss_link: str, headers: Dict[str, str] = None
+    rss_link: str, headers: Optional[Dict[str, str]] = None
 ) -> feedparser.FeedParserDict:
     if urlsplit(rss_link).scheme not in ("http", "https"):
         return feedparser.parse(rss_link)
 
-    request_headers = headers or {"User-Agent": "podcast-downloader"}
+    request_headers = (
+        headers if headers is not None else {"User-Agent": "podcast-downloader"}
+    )
 
     try:
         request = urllib.request.Request(rss_link, headers=request_headers)

--- a/tests/rss_resilience_test.py
+++ b/tests/rss_resilience_test.py
@@ -27,12 +27,22 @@ class RssResilienceTest(unittest.TestCase):
         entries = [
             {
                 "title": "Missing date",
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/bad.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/bad.mp3",
+                    }
+                ],
             },
             {
                 "title": "Valid episode",
                 "published_parsed": valid_date,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/good.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/good.mp3",
+                    }
+                ],
             },
         ]
 
@@ -47,7 +57,12 @@ class RssResilienceTest(unittest.TestCase):
         entries = [
             {
                 "updated_parsed": updated_date,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/ep.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/ep.mp3",
+                    }
+                ],
             }
         ]
 
@@ -77,12 +92,22 @@ class RssResilienceTest(unittest.TestCase):
             {
                 "title": "Older",
                 "published_parsed": older,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/old.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/old.mp3",
+                    }
+                ],
             },
             {
                 "title": "Newer",
                 "published_parsed": newer,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/new.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/new.mp3",
+                    }
+                ],
             },
         ]
 
@@ -97,17 +122,32 @@ class RssResilienceTest(unittest.TestCase):
             {
                 "title": "Newest",
                 "published_parsed": newest,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/new.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/new.mp3",
+                    }
+                ],
             },
             {
                 "title": "First tied",
                 "published_parsed": tied,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/first.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/first.mp3",
+                    }
+                ],
             },
             {
                 "title": "Second tied",
                 "published_parsed": tied,
-                "links": [{"type": "audio/mpeg", "href": "https://example.com/second.mp3"}],
+                "links": [
+                    {
+                        "type": "audio/mpeg",
+                        "href": "https://example.com/second.mp3",
+                    }
+                ],
             },
         ]
 
@@ -115,6 +155,34 @@ class RssResilienceTest(unittest.TestCase):
 
         self.assertEqual(
             ["Newest", "First tied", "Second tied"], [entry.title for entry in result]
+        )
+
+    def test_descending_feed_with_recent_bottom_entry_is_not_reversed(self):
+        entries = []
+        for title, date in (
+            ("Episode 10", "2026-08-10"),
+            ("Episode 9", "2026-08-09"),
+            ("Episode 8", "2026-08-08"),
+            ("Trailer", "2026-08-20"),
+        ):
+            entries.append(
+                {
+                    "title": title,
+                    "published_parsed": time.strptime(date, "%Y-%m-%d"),
+                    "links": [
+                        {
+                            "type": "audio/mpeg",
+                            "href": f"https://example.com/{title}.mp3",
+                        }
+                    ],
+                }
+            )
+
+        result = list(flatten_rss_links_data(iter(entries)))
+
+        self.assertEqual(
+            ["Episode 10", "Episode 9", "Episode 8", "Trailer"],
+            [entry.title for entry in result],
         )
 
     def test_missing_feed_title_returns_empty_string(self):
@@ -128,7 +196,10 @@ class RssResilienceTest(unittest.TestCase):
         self.assertEqual("", get_feed_title_from_feed(Feed(feed)))
 
     def test_feed_download_uses_timeout_and_configured_headers(self):
-        xml = b"""<?xml version='1.0'?><rss version='2.0'><channel><title>Test</title></channel></rss>"""
+        xml = (
+            b"<?xml version='1.0'?><rss version='2.0'><channel>"
+            b"<title>Test</title></channel></rss>"
+        )
         headers = {"User-Agent": "custom-agent", "Authorization": "Bearer test"}
 
         with patch(
@@ -144,7 +215,10 @@ class RssResilienceTest(unittest.TestCase):
         self.assertEqual("Bearer test", request.get_header("Authorization"))
 
     def test_local_feed_path_remains_supported(self):
-        xml = """<?xml version='1.0'?><rss version='2.0'><channel><title>Local</title></channel></rss>"""
+        xml = (
+            "<?xml version='1.0'?><rss version='2.0'><channel>"
+            "<title>Local</title></channel></rss>"
+        )
 
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "feed.xml"

--- a/tests/rss_resilience_test.py
+++ b/tests/rss_resilience_test.py
@@ -214,6 +214,22 @@ class RssResilienceTest(unittest.TestCase):
         self.assertEqual("custom-agent", request.get_header("User-agent"))
         self.assertEqual("Bearer test", request.get_header("Authorization"))
 
+    def test_explicit_empty_headers_are_preserved(self):
+        xml = (
+            b"<?xml version='1.0'?><rss version='2.0'><channel>"
+            b"<title>Test</title></channel></rss>"
+        )
+
+        with patch(
+            "podcast_downloader.rss.urllib.request.urlopen",
+            return_value=Response(xml),
+        ) as urlopen:
+            feed = load_feed("https://example.com/feed.xml", {})
+
+        self.assertEqual("Test", feed.feed.title)
+        request = urlopen.call_args.args[0]
+        self.assertIsNone(request.get_header("User-agent"))
+
     def test_local_feed_path_remains_supported(self):
         xml = (
             "<?xml version='1.0'?><rss version='2.0'><channel>"

--- a/tests/rss_resilience_test.py
+++ b/tests/rss_resilience_test.py
@@ -1,0 +1,106 @@
+import io
+import time
+import unittest
+from unittest.mock import patch
+
+from podcast_downloader.rss import (
+    FEED_TIMEOUT_SECONDS,
+    flatten_rss_links_data,
+    get_feed_title_from_feed,
+    load_feed,
+)
+
+
+class Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+class RssResilienceTest(unittest.TestCase):
+    def test_malformed_entry_does_not_hide_following_valid_entry(self):
+        valid_date = time.gmtime()
+        entries = [
+            {
+                "title": "Missing date",
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/bad.mp3"}],
+            },
+            {
+                "title": "Valid episode",
+                "published_parsed": valid_date,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/good.mp3"}],
+            },
+        ]
+
+        result = list(flatten_rss_links_data(iter(entries)))
+
+        self.assertEqual(1, len(result))
+        self.assertEqual("Valid episode", result[0].title)
+        self.assertEqual("https://example.com/good.mp3", result[0].link)
+
+    def test_updated_date_is_used_when_published_date_is_missing(self):
+        updated_date = time.gmtime()
+        entries = [
+            {
+                "updated_parsed": updated_date,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/ep.mp3"}],
+            }
+        ]
+
+        result = list(flatten_rss_links_data(iter(entries)))
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(updated_date, result[0].published_date)
+        self.assertEqual("", result[0].title)
+
+    def test_links_without_type_or_href_are_skipped(self):
+        entries = [
+            {
+                "published_parsed": time.gmtime(),
+                "links": [
+                    {"href": "https://example.com/no-type.mp3"},
+                    {"type": "audio/mpeg"},
+                ],
+            }
+        ]
+
+        self.assertEqual([], list(flatten_rss_links_data(iter(entries))))
+
+    def test_missing_feed_title_returns_empty_string(self):
+        feed = {"feed": {}}
+
+        class Feed(dict):
+            @property
+            def feed(self):
+                return self["feed"]
+
+        self.assertEqual("", get_feed_title_from_feed(Feed(feed)))
+
+    def test_feed_download_uses_timeout(self):
+        xml = b"""<?xml version='1.0'?><rss version='2.0'><channel><title>Test</title></channel></rss>"""
+
+        with patch(
+            "podcast_downloader.rss.urllib.request.urlopen",
+            return_value=Response(xml),
+        ) as urlopen:
+            feed = load_feed("https://example.com/feed.xml")
+
+        self.assertEqual("Test", feed.feed.title)
+        self.assertEqual(FEED_TIMEOUT_SECONDS, urlopen.call_args.kwargs["timeout"])
+
+    def test_feed_network_error_becomes_bozo_feed(self):
+        with patch(
+            "podcast_downloader.rss.urllib.request.urlopen",
+            side_effect=TimeoutError("timeout"),
+        ):
+            feed = load_feed("https://example.com/feed.xml")
+
+        self.assertTrue(feed.bozo)
+        self.assertEqual([], feed.entries)
+        self.assertIsInstance(feed.bozo_exception, TimeoutError)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/rss_resilience_test.py
+++ b/tests/rss_resilience_test.py
@@ -1,6 +1,8 @@
 import io
+import tempfile
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from podcast_downloader.rss import (
@@ -68,7 +70,7 @@ class RssResilienceTest(unittest.TestCase):
 
         self.assertEqual([], list(flatten_rss_links_data(iter(entries))))
 
-    def test_entries_are_normalized_newest_first(self):
+    def test_ascending_entries_are_reversed(self):
         older = time.strptime("2026-08-01", "%Y-%m-%d")
         newer = time.strptime("2026-08-02", "%Y-%m-%d")
         entries = [
@@ -88,6 +90,33 @@ class RssResilienceTest(unittest.TestCase):
 
         self.assertEqual(["Newer", "Older"], [entry.title for entry in result])
 
+    def test_descending_entries_keep_their_order_including_ties(self):
+        newest = time.strptime("2026-08-03", "%Y-%m-%d")
+        tied = time.strptime("2026-08-02", "%Y-%m-%d")
+        entries = [
+            {
+                "title": "Newest",
+                "published_parsed": newest,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/new.mp3"}],
+            },
+            {
+                "title": "First tied",
+                "published_parsed": tied,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/first.mp3"}],
+            },
+            {
+                "title": "Second tied",
+                "published_parsed": tied,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/second.mp3"}],
+            },
+        ]
+
+        result = list(flatten_rss_links_data(iter(entries)))
+
+        self.assertEqual(
+            ["Newest", "First tied", "Second tied"], [entry.title for entry in result]
+        )
+
     def test_missing_feed_title_returns_empty_string(self):
         feed = {"feed": {}}
 
@@ -98,17 +127,31 @@ class RssResilienceTest(unittest.TestCase):
 
         self.assertEqual("", get_feed_title_from_feed(Feed(feed)))
 
-    def test_feed_download_uses_timeout(self):
+    def test_feed_download_uses_timeout_and_configured_headers(self):
         xml = b"""<?xml version='1.0'?><rss version='2.0'><channel><title>Test</title></channel></rss>"""
+        headers = {"User-Agent": "custom-agent", "Authorization": "Bearer test"}
 
         with patch(
             "podcast_downloader.rss.urllib.request.urlopen",
             return_value=Response(xml),
         ) as urlopen:
-            feed = load_feed("https://example.com/feed.xml")
+            feed = load_feed("https://example.com/feed.xml", headers)
 
         self.assertEqual("Test", feed.feed.title)
         self.assertEqual(FEED_TIMEOUT_SECONDS, urlopen.call_args.kwargs["timeout"])
+        request = urlopen.call_args.args[0]
+        self.assertEqual("custom-agent", request.get_header("User-agent"))
+        self.assertEqual("Bearer test", request.get_header("Authorization"))
+
+    def test_local_feed_path_remains_supported(self):
+        xml = """<?xml version='1.0'?><rss version='2.0'><channel><title>Local</title></channel></rss>"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "feed.xml"
+            path.write_text(xml, encoding="utf-8")
+            feed = load_feed(str(path))
+
+        self.assertEqual("Local", feed.feed.title)
 
     def test_feed_network_error_becomes_bozo_feed(self):
         with patch(

--- a/tests/rss_resilience_test.py
+++ b/tests/rss_resilience_test.py
@@ -68,6 +68,26 @@ class RssResilienceTest(unittest.TestCase):
 
         self.assertEqual([], list(flatten_rss_links_data(iter(entries))))
 
+    def test_entries_are_normalized_newest_first(self):
+        older = time.strptime("2026-08-01", "%Y-%m-%d")
+        newer = time.strptime("2026-08-02", "%Y-%m-%d")
+        entries = [
+            {
+                "title": "Older",
+                "published_parsed": older,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/old.mp3"}],
+            },
+            {
+                "title": "Newer",
+                "published_parsed": newer,
+                "links": [{"type": "audio/mpeg", "href": "https://example.com/new.mp3"}],
+            },
+        ]
+
+        result = list(flatten_rss_links_data(iter(entries)))
+
+        self.assertEqual(["Newer", "Older"], [entry.title for entry in result])
+
     def test_missing_feed_title_returns_empty_string(self):
         feed = {"feed": {}}
 


### PR DESCRIPTION
A failed or malformed RSS feed can currently abort the run, and a server that does not respond can leave it waiting indefinitely.

This makes feed loading and entry parsing more defensive:

* network errors are reported and the run moves on to the next podcast;
* remote feed requests use a 30-second timeout;
* configured HTTP headers are passed when loading the feed;
* missing feed titles fall back to the RSS URL;
* entries without a publication date, link type or URL are skipped instead of raising;
* `updated` is used when `published` is unavailable;
* consistently ascending feeds are normalized without reversing mixed-order feeds.

Regression tests cover malformed feed data, headers, local feeds, ordering, equal timestamps and mixed-order feeds.

An explicitly empty `http_headers: {}` is now preserved as empty rather than restoring the default `podcast-downloader` User-Agent. In that case `urllib` may send its own default User-Agent instead.

This also improves handling of SSL failures such as #81 by reporting the error and continuing with other podcasts. It does not change certificate verification or make a feed with an invalid certificate downloadable.

Fixes #82
