### PR TITLE
Preserve ordinal indicators in filenames

### DIFF
--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -42,7 +42,10 @@ def link_to_extension(link: str) -> str:
 
 
 def str_to_filename(value: str) -> str:
-    value = unicodedata.normalize("NFKC", value)
+    value = "".join(
+        part if part in ("º", "ª") else unicodedata.normalize("NFKC", part)
+        for part in re.split(r"([ºª])", value)
+    )
     value = re.sub(r"[\u0000-\u001F\u007F\*/:<>\"\?\\\|]", " ", value)
 
     return value.strip()

--- a/tests/file_template_test.py
+++ b/tests/file_template_test.py
@@ -92,6 +92,8 @@ class TestFileTemplateToFileNameConverter(unittest.TestCase):
         test_parameters = [
             ("Ala ma kota", "Ala ma kota"),
             (" abcdefg hijk ", "abcdefg hijk"),
+            ("2º Cromo", "2º Cromo"),
+            ("1ª Parte", "1ª Parte"),
             (
                 "AEE 226: How to 80/20 Your English to Make More Friends with italki Teacher Nick Vance",
                 "AEE 226  How to 80 20 Your English to Make More Friends with italki Teacher Nick Vance",


### PR DESCRIPTION
`str_to_filename()` currently applies NFKC normalization to the full title, which changes ordinal indicators such as `º` and `ª` into `o` and `a`.

I kept the existing NFKC normalization for the rest of the filename and only preserve those two ordinal indicators before normalization. This keeps the existing filename compatibility behavior while avoiding changes such as `2º Cromo` -> `2o Cromo`.

Regression tests cover both masculine and feminine ordinal indicators.

Tested with:

* `python -m unittest discover -s tests -p "*_test.py"` — 35 passed
* `pytest e2e` — 21 passed

### Compatibility note

Because episode identity is still derived from the file name, titles containing `º` or `ª` will resolve to a different name than before this change (`2o Cromo.mp3` -> `2º Cromo.mp3`). On the first run after upgrading, those episodes will no longer match files that were saved with the old normalized name and will fall back to `if_directory_empty`:

* `download_last` (default) may re-download one episode per affected podcast;
* `download_all_from_feed` may re-download the affected feed.

Renaming existing files to the new form before upgrading avoids that mismatch.

### Scope

This change only preserves `º` (U+00BA) and `ª` (U+00AA). Other NFKC compatibility mappings are unchanged and still apply, for example `№` -> `No`, `²` -> `2` and `ﬁ` -> `fi`.

Fixes #79
