### PR TITLE
Follow RSS pagination links

### DIFF
--- a/e2e/test_rss_pagination.py
+++ b/e2e/test_rss_pagination.py
@@ -1,0 +1,82 @@
+from typing import Callable, Dict, List
+
+from pytest_httpserver import HTTPServer
+
+from e2e.fixures import (
+    PodcastDirectory,
+    PodcastDownloaderRunner,
+    download_destination_directory,
+    podcast_directory,
+    podcast_downloader,
+    use_config,
+)
+
+
+def build_rss_page(title: str, enclosure_url: str, published: str, next_link=None):
+    pagination_link = (
+        f'<atom:link rel="next" type="application/rss+xml" href="{next_link}"/>'
+        if next_link
+        else ""
+    )
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Paginated podcast</title>
+    {pagination_link}
+    <item>
+      <title>{title}</title>
+      <pubDate>{published}</pubDate>
+      <enclosure url="{enclosure_url}" length="11" type="audio/mpeg"/>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def test_downloads_entries_from_all_rss_pages(
+    httpserver: HTTPServer,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: Callable[[List[str]], PodcastDownloaderRunner],
+    podcast_directory: PodcastDirectory,
+):
+    first_file = "first-page.mp3"
+    second_file = "second-page.mp3"
+    first_file_url = httpserver.url_for("/" + first_file)
+    second_file_url = httpserver.url_for("/" + second_file)
+
+    httpserver.expect_request("/feed.xml").respond_with_data(
+        build_rss_page(
+            "First page episode",
+            first_file_url,
+            "Fri, 04 Sep 2026 10:00:00 +0000",
+            "/feed-page-2.xml",
+        ),
+        content_type="application/rss+xml",
+    )
+    httpserver.expect_request("/feed-page-2.xml").respond_with_data(
+        build_rss_page(
+            "Second page episode",
+            second_file_url,
+            "Thu, 03 Sep 2026 10:00:00 +0000",
+        ),
+        content_type="application/rss+xml",
+    )
+    httpserver.expect_request("/" + first_file).respond_with_data("first audio")
+    httpserver.expect_request("/" + second_file).respond_with_data("second audio")
+
+    use_config(
+        {
+            "if_directory_empty": "download_all_from_feed",
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": httpserver.url_for("/feed.xml"),
+                }
+            ],
+        }
+    )
+
+    podcast_downloader.run()
+
+    podcast_directory.is_containing_only([first_file, second_file])

--- a/podcast_downloader/rss.py
+++ b/podcast_downloader/rss.py
@@ -3,10 +3,10 @@ import time
 from dataclasses import dataclass
 from functools import partial
 from itertools import takewhile, islice
-from typing import Callable, Generator, Iterator, List
+from typing import Callable, Generator, Iterator, List, Optional
 import unicodedata
 import feedparser
-from urllib.parse import urlsplit, unquote
+from urllib.parse import urljoin, urlsplit, unquote
 
 
 FILE_NAME_CHARACTER_LIMIT = 255
@@ -89,8 +89,35 @@ def limit_file_name(maximum_length: int, file_name: str) -> str:
     )
 
 
+def get_next_feed_link(feed: feedparser.FeedParserDict) -> Optional[str]:
+    for link in feed.get("feed", {}).get("links", []):
+        if str(link.get("rel", "")).lower() == "next" and link.get("href"):
+            return link["href"]
+
+    return None
+
+
 def load_feed(rss_link: str) -> feedparser.FeedParserDict:
-    return feedparser.parse(rss_link)
+    feed = feedparser.parse(rss_link)
+    current_feed = feed
+    current_link = rss_link
+    visited_links = {rss_link}
+
+    while True:
+        next_link = get_next_feed_link(current_feed)
+        if not next_link:
+            break
+
+        next_link = urljoin(current_feed.get("href", current_link), next_link)
+        if next_link in visited_links:
+            break
+
+        visited_links.add(next_link)
+        current_feed = feedparser.parse(next_link)
+        feed.entries.extend(current_feed.entries)
+        current_link = next_link
+
+    return feed
 
 
 def get_feed_title_from_feed(feedParser: feedparser.FeedParserDict) -> str:

--- a/tests/rss_pagination_test.py
+++ b/tests/rss_pagination_test.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import call, patch
+
+from podcast_downloader.rss import load_feed
+
+
+class FakeFeed(dict):
+    def __init__(self, entries, links=None, href=None):
+        super().__init__(feed={"links": links or []})
+        if href:
+            self["href"] = href
+        self.entries = list(entries)
+
+
+class RssPaginationTest(unittest.TestCase):
+    @patch("podcast_downloader.rss.feedparser.parse")
+    def test_load_feed_follows_next_links_and_combines_entries(self, parse):
+        first_page = FakeFeed(
+            ["first"],
+            [{"rel": "next", "href": "?page=2"}],
+        )
+        second_page = FakeFeed(
+            ["second"],
+            [{"rel": "next", "href": "page3.xml"}],
+        )
+        third_page = FakeFeed(["third"])
+        parse.side_effect = [first_page, second_page, third_page]
+
+        feed = load_feed("https://example.com/show/feed.xml?page=1")
+
+        self.assertIs(feed, first_page)
+        self.assertEqual(["first", "second", "third"], feed.entries)
+        self.assertEqual(
+            [
+                call("https://example.com/show/feed.xml?page=1"),
+                call("https://example.com/show/feed.xml?page=2"),
+                call("https://example.com/show/page3.xml"),
+            ],
+            parse.call_args_list,
+        )
+
+    @patch("podcast_downloader.rss.feedparser.parse")
+    def test_load_feed_stops_when_next_link_creates_cycle(self, parse):
+        first_page = FakeFeed(
+            ["first"],
+            [{"rel": "next", "href": "?page=2"}],
+        )
+        second_page = FakeFeed(
+            ["second"],
+            [{"rel": "next", "href": "?page=1"}],
+        )
+        parse.side_effect = [first_page, second_page]
+
+        feed = load_feed("https://example.com/feed?page=1")
+
+        self.assertEqual(["first", "second"], feed.entries)
+        self.assertEqual(2, parse.call_count)
+
+    @patch("podcast_downloader.rss.feedparser.parse")
+    def test_load_feed_ignores_links_that_are_not_next(self, parse):
+        first_page = FakeFeed(
+            ["first"],
+            [
+                {"rel": "self", "href": "https://example.com/feed.xml"},
+                {"rel": "next"},
+            ],
+        )
+        parse.return_value = first_page
+
+        feed = load_feed("https://example.com/feed.xml")
+
+        self.assertEqual(["first"], feed.entries)
+        self.assertEqual(1, parse.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Some podcast feeds split their episode history across multiple RSS pages and expose the next page through `atom:link rel="next"`. The downloader currently only reads the first page, so older episodes are silently missed.

This follows `rel="next"` links until there are no more pages and combines their entries into the initial feed before the normal filtering/downloading logic runs.

It also:

* supports absolute and relative pagination links;
* preserves page order when combining entries;
* tracks visited URLs so cyclic pagination links cannot loop forever;
* ignores unrelated or incomplete feed links.

Regression tests cover multi-page traversal, relative URLs, cycle prevention and non-pagination links. An end-to-end test verifies that episodes from two RSS pages are both downloaded.

Tested with:

* `python -m unittest discover -s tests -p "*_test.py"` — 38 passed
* `pytest e2e` — 22 passed

Fixes #77
