### PR TITLE
Add end-of-run error summary

### DIFF
--- a/e2e/test_error_summary.py
+++ b/e2e/test_error_summary.py
@@ -1,3 +1,4 @@
+import re
 from typing import Callable, Dict
 
 from pytest_httpserver import HTTPServer
@@ -53,6 +54,11 @@ def test_failed_download_is_repeated_in_final_error_summary(
     runner = podcast_downloader.run()
     output = runner.get_output()
 
-    assert runner.is_containing("Finished with 1 recoverable error:")
+    plain_output = [
+        re.sub(r"\x1b\[[0-9;]*m", "", line) for line in output
+    ]
+    assert any(
+        "Finished with 1 recoverable error:" in line for line in plain_output
+    )
     assert sum("could not be saved to disk" in line for line in output) == 2
     assert podcast_directory.get_files_list() == set()

--- a/e2e/test_error_summary.py
+++ b/e2e/test_error_summary.py
@@ -1,0 +1,58 @@
+from typing import Callable, Dict
+
+from pytest_httpserver import HTTPServer
+
+from e2e.fixures import (
+    PodcastDirectory,
+    PodcastDownloaderRunner,
+    download_destination_directory,
+    podcast_directory,
+    podcast_downloader,
+    use_config,
+)
+
+
+def test_failed_download_is_repeated_in_final_error_summary(
+    httpserver: HTTPServer,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: PodcastDownloaderRunner,
+    podcast_directory: PodcastDirectory,
+):
+    file_name = "broken.mp3"
+    audio_url = httpserver.url_for("/" + file_name)
+    feed_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Error summary podcast</title>
+    <item>
+      <title>Broken episode</title>
+      <pubDate>Fri, 04 Sep 2026 10:00:00 +0000</pubDate>
+      <enclosure url="{audio_url}" length="4" type="audio/mpeg"/>
+    </item>
+  </channel>
+</rss>
+"""
+
+    httpserver.expect_request("/feed.xml").respond_with_data(
+        feed_xml, content_type="application/rss+xml"
+    )
+    httpserver.expect_request("/" + file_name).respond_with_data("boom", status=500)
+
+    use_config(
+        {
+            "if_directory_empty": "download_all_from_feed",
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": httpserver.url_for("/feed.xml"),
+                }
+            ],
+        }
+    )
+
+    runner = podcast_downloader.run()
+    output = runner.get_output()
+
+    assert runner.is_containing("Finished with 1 recoverable error:")
+    assert sum("could not be saved to disk" in line for line in output) == 2
+    assert podcast_directory.get_files_list() == set()

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -385,7 +385,7 @@ if __name__ == "__main__":
     if error_summary_handler.messages:
         error_count = len(error_summary_handler.messages)
         error_label = "error" if error_count == 1 else "errors"
-        logger.info(f"Finished with {error_count} recoverable {error_label}:")
+        logger.info("Finished with %d recoverable %s:", error_count, error_label)
         for error_message in error_summary_handler.messages:
             logger.info("- %s", error_message)
     else:

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -15,7 +15,7 @@ from podcast_downloader.configuration import (
     get_n_age_date,
     parse_day_label,
 )
-from .utils import ConsoleOutputFormatter, compose
+from .utils import ConsoleOutputFormatter, ErrorSummaryHandler, compose
 from .downloaded import (
     get_downloaded_files,
     get_extensions_checker,
@@ -197,8 +197,10 @@ if __name__ == "__main__":
 
     logger = getLogger(__name__)
     logger.setLevel(INFO)
+    error_summary_handler = ErrorSummaryHandler()
     stdout_handler = StreamHandler(stream=sys.stdout)
     stdout_handler.setFormatter(ConsoleOutputFormatter())
+    logger.addHandler(error_summary_handler)
     logger.addHandler(stdout_handler)
 
     DEFAULT_CONFIGURATION = {
@@ -380,4 +382,11 @@ if __name__ == "__main__":
         else:
             logger.info("%s: Nothing new", rss_source_name)
 
-    logger.info("Finished")
+    if error_summary_handler.messages:
+        error_count = len(error_summary_handler.messages)
+        error_label = "error" if error_count == 1 else "errors"
+        logger.info(f"Finished with {error_count} recoverable {error_label}:")
+        for error_message in error_summary_handler.messages:
+            logger.info("- %s", error_message)
+    else:
+        logger.info("Finished")

--- a/podcast_downloader/utils.py
+++ b/podcast_downloader/utils.py
@@ -1,13 +1,14 @@
 from functools import reduce
-from logging import ERROR, Formatter, Handler, WARNING
+from logging import ERROR, Formatter, Handler, LogRecord, WARNING
+from typing import List
 
 
 class ErrorSummaryHandler(Handler):
     def __init__(self) -> None:
         super().__init__(ERROR)
-        self.messages = []
+        self.messages: List[str] = []
 
-    def emit(self, record) -> None:
+    def emit(self, record: LogRecord) -> None:
         try:
             self.messages.append(record.getMessage())
         except Exception:

--- a/podcast_downloader/utils.py
+++ b/podcast_downloader/utils.py
@@ -1,5 +1,17 @@
 from functools import reduce
-from logging import Formatter, WARNING, ERROR
+from logging import ERROR, Formatter, Handler, WARNING
+
+
+class ErrorSummaryHandler(Handler):
+    def __init__(self) -> None:
+        super().__init__(ERROR)
+        self.messages = []
+
+    def emit(self, record) -> None:
+        try:
+            self.messages.append(record.getMessage())
+        except Exception:
+            self.handleError(record)
 
 
 class ConsoleOutputFormatter(Formatter):

--- a/tests/error_summary_test.py
+++ b/tests/error_summary_test.py
@@ -1,0 +1,33 @@
+import logging
+import unittest
+
+from podcast_downloader.utils import ErrorSummaryHandler
+
+
+class ErrorSummaryHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger(f"{__name__}.{self._testMethodName}")
+        self.logger.handlers = []
+        self.logger.propagate = False
+        self.logger.setLevel(logging.DEBUG)
+        self.handler = ErrorSummaryHandler()
+        self.logger.addHandler(self.handler)
+
+    def test_only_error_messages_are_collected(self):
+        self.logger.info("informational")
+        self.logger.warning("warning")
+        self.logger.error("Feed %s failed", "example")
+
+        self.assertEqual(["Feed example failed"], self.handler.messages)
+
+    def test_exception_traceback_is_not_stored_in_summary(self):
+        try:
+            raise ValueError("details")
+        except ValueError:
+            self.logger.exception("Download failed")
+
+        self.assertEqual(["Download failed"], self.handler.messages)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Recoverable errors are currently logged when they happen, but in longer runs they can be easy to miss among the normal output.

This adds a lightweight error collector that records messages already emitted at `ERROR` level and repeats them in a short summary at the end of a successful run.

It keeps the existing behavior intact:

* errors are still logged immediately when they occur;
* exception tracebacks are not duplicated in the final summary;
* warnings and informational messages are not collected;
* recoverable errors do not change the process exit code;
* runs without errors still finish with the existing `Finished` message.

Regression tests cover filtering by log level, exception messages without traceback duplication, and an end-to-end failed download that is reported both when it occurs and in the final summary.

Tested with:

* `python -m unittest discover -s tests -p "*_test.py"` — 37 passed
* `pytest e2e` — 22 passed
