### PR TITLE
Document and test configurable media type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It does not use any sort of database but requires a configuration file.
 The script is intended to be run periodically. Upon starting, it analyzes the directory where it previously stored downloaded files.
 It then compares these files with those listed in the RSS feed, identifying any missing ones and downloading them.
 
-The files searched by default are `mp3`.
+By default, Podcast Downloader downloads `.mp3` enclosures with MIME type `audio/mpeg`. Other media types, including video, can be enabled with `podcast_extensions`.
 
 The result of using the [example below](#configuration), on empty directories, will be:
 
@@ -159,7 +159,7 @@ Example:
       "name": "Unua Podcast",
       "rss_link": "http://www.unuapodcast.org/feed.rss",
       "path": "~/podcasts/unua_podcast",
-      "https_headers": {
+      "http_headers": {
         "User-Agent": "Mozilla/5.0"
       }
     },
@@ -167,7 +167,7 @@ Example:
       "name": "Dua Podcast",
       "rss_link": "http://www.duapodcast.org/feed.rss",
       "path": "~/podcasts/dua_podcast",
-      "https_headers": {
+      "http_headers": {
         "Authorization": "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
       }
     }
@@ -195,7 +195,7 @@ The script accepts following command line arguments:
 | Short version | Long name              | Parameter           | Default                             | Note |
 |:--------------|:-----------------------|:-------------------:|:-----------------------------------:|:-----|
 |               | `--config`             | string              | `~/.podcast_downloader_config.json` | The placement of the configuration file |
-|               | `--downloads_limit`    | number              | infinity                            | The maximum number of downloaded mp3 files |
+|               | `--downloads_limit`    | number              | infinity                            | The maximum number of downloaded media files |
 |               | `--if_directory_empty` | string              | `download_last`                     | The general approach on empty directory |
 |               | `--download_delay`     | number              | `0`                                 | The waiting time (seconds) between downloads |
 
@@ -231,26 +231,31 @@ The `%publish_date%` by default gives result in format `YEARMMDD`. In order to c
 
 ## File types filter
 
-Podcasts are mostly stored as `*.mp3` files. By default Podcast Downloader looks just for them, ignoring all others types.
+Podcast Downloader filters RSS enclosure links by MIME type. By default it downloads only `.mp3` files advertised as `audio/mpeg`.
 
-If your podcast supports other types of media files, you can specified the file filters. Provide the  extension of the file (like `.mp3`) and type of link in RSS feed itself (for `mp3` it is `audio/mpeg`).
+Other audio or video media types can be enabled with `podcast_extensions`. Each entry maps the local file extension to the MIME type advertised by the RSS `<enclosure>` element. The downloader saves the enclosure as-is; it does not transcode or convert media.
 
-If you don't know the type of the file, you can look for it in the RSS file. Seek for `enclosure` tags, should looks like this:
+Setting `podcast_extensions` replaces the default mapping rather than extending it. Include `".mp3": "audio/mpeg"` if you want to keep downloading MP3 enclosures alongside additional media types.
+
+For example, a videocast that publishes MP4 enclosures can be enabled with `".mp4": "video/mp4"`.
+
+If you don't know the file type, look for the `enclosure` tags in the RSS feed. They should look like this:
 
 ```xml
-  <enclosure url="https://www.vidocast.url/podcast/episode23.m4a"
+  <enclosure url="https://www.videocast.url/podcast/episode23.mp4"
              length="14527149"
-             type="audio/x-m4a" />
+             type="video/mp4" />
 ```
 
-**Note**: the dot on the file extension is require.
+**Note**: the dot on the file extension is required.
 
 ### Example
 
 ```json
   "podcast_extensions": {
     ".mp3": "audio/mpeg",
-    ".m4a": "audio/x-m4a"
+    ".m4a": "audio/x-m4a",
+    ".mp4": "video/mp4"
   }
 ```
 

--- a/e2e/test_media_types.py
+++ b/e2e/test_media_types.py
@@ -1,0 +1,38 @@
+from typing import Callable, Dict
+
+from e2e.fixures import (
+    FeedBuilder,
+    PodcastDirectory,
+    PodcastDownloaderRunner,
+    download_destination_directory,  # noqa: F401 - required by podcast_directory
+    feed,  # noqa: F401 - pytest fixture imported for discovery
+    podcast_directory,  # noqa: F401 - pytest fixture imported for discovery
+    podcast_downloader,  # noqa: F401 - pytest fixture imported for discovery
+    use_config,  # noqa: F401 - pytest fixture imported for discovery
+)
+
+
+def test_configured_video_media_type_is_downloaded(
+    feed: FeedBuilder,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: PodcastDownloaderRunner,
+    podcast_directory: PodcastDirectory,
+):
+    video_file = "episode.mp4"
+    feed.add_entry(file_name=video_file, file_type="video/mp4")
+
+    use_config(
+        {
+            "podcast_extensions": {".mp4": "video/mp4"},
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": feed.get_feed_url(),
+                }
+            ],
+        }
+    )
+
+    podcast_downloader.run()
+
+    podcast_directory.is_containing_only([video_file])

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -67,7 +67,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--downloads_limit",
         required=False,
         type=int,
-        help="The maximum number of mp3 files which script will download",
+        help="The maximum number of media files the script will download",
     )
 
     parser.add_argument(


### PR DESCRIPTION
Podcast Downloader already supports media types beyond the default MP3 enclosure when `podcast_extensions` is configured, but parts of the README still describe the tool as MP3-only and do not show a video example.

This updates the documentation to match the existing behavior and adds an end-to-end regression test for a `video/mp4` enclosure.

The README changes also correct a few existing configuration inaccuracies:

* podcast-level header examples use the actual `http_headers` option instead of `https_headers`;
* `downloads_limit` is described in terms of media files rather than MP3 files;
* `podcast_extensions` is clarified as replacing the default media mapping rather than extending it;
* the file type section makes clear that configured enclosure types are downloaded as-is without transcoding.

Tested with:

* `python -m unittest discover -s tests -p "*_test.py"` — 35 passed
* `pytest e2e` — 22 passed
