### PR TITLE
Add optional podcast cover downloads

### DIFF
--- a/e2e/test_podcast_cover.py
+++ b/e2e/test_podcast_cover.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+from typing import Callable, Dict, List
+
+from e2e.fixures import (
+    PodcastDirectory,
+    PodcastDownloaderRunner,
+    download_destination_directory,
+    podcast_directory,
+    podcast_downloader,
+    use_config,
+)
+
+
+def build_feed(cover_markup: str) -> str:
+    return f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<rss xmlns:itunes=\"http://www.itunes.com/dtds/podcast-1.0.dtd\" version=\"2.0\">
+  <channel>
+    <title>Cover Test</title>
+    <link>https://example.com</link>
+    <description>Cover test feed</description>
+    {cover_markup}
+  </channel>
+</rss>
+"""
+
+
+def test_podcast_cover_is_disabled_by_default(
+    httpserver,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: Callable[[List[str]], PodcastDownloaderRunner],
+    podcast_directory: PodcastDirectory,
+):
+    cover_url = httpserver.url_for("/cover.jpg")
+    httpserver.expect_request("/feed.xml").respond_with_data(
+        build_feed(f"<image><url>{cover_url}</url></image>"),
+        content_type="application/rss+xml",
+    )
+
+    use_config(
+        {
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": httpserver.url_for("/feed.xml"),
+                }
+            ]
+        }
+    )
+
+    podcast_downloader.run()
+
+    requested_paths = [request.path for request, _ in httpserver.log]
+    assert requested_paths == ["/feed.xml"]
+    podcast_directory.is_containing_only([])
+
+
+def test_rss_podcast_cover_is_downloaded_when_enabled(
+    httpserver,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: Callable[[List[str]], PodcastDownloaderRunner],
+    podcast_directory: PodcastDirectory,
+):
+    cover_url = httpserver.url_for("/cover.jpg?size=1500")
+    httpserver.expect_request("/feed.xml").respond_with_data(
+        build_feed(f"<image><url>{cover_url}</url></image>"),
+        content_type="application/rss+xml",
+    )
+    httpserver.expect_request("/cover.jpg", query_string="size=1500").respond_with_data(
+        b"rss-cover", content_type="image/jpeg"
+    )
+
+    use_config(
+        {
+            "download_podcast_cover": True,
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": httpserver.url_for("/feed.xml"),
+                }
+            ],
+        }
+    )
+
+    podcast_downloader.run()
+
+    cover_path = Path(podcast_directory.path()) / "cover.jpg"
+    assert cover_path.read_bytes() == b"rss-cover"
+    podcast_directory.is_containing_only(["cover.jpg"])
+
+
+def test_itunes_podcast_cover_uses_content_type_and_podcast_headers(
+    httpserver,
+    use_config: Callable[[Dict], None],
+    podcast_downloader: Callable[[List[str]], PodcastDownloaderRunner],
+    podcast_directory: PodcastDirectory,
+):
+    cover_url = httpserver.url_for("/artwork")
+    httpserver.expect_request("/feed.xml").respond_with_data(
+        build_feed(f'<itunes:image href="{cover_url}" />'),
+        content_type="application/rss+xml",
+    )
+    httpserver.expect_request(
+        "/artwork", headers={"X-Cover-Test": "enabled"}
+    ).respond_with_data(b"itunes-cover", content_type="image/png")
+
+    use_config(
+        {
+            "podcasts": [
+                {
+                    "path": podcast_directory.path(),
+                    "rss_link": httpserver.url_for("/feed.xml"),
+                    "download_podcast_cover": True,
+                    "http_headers": {"X-Cover-Test": "enabled"},
+                }
+            ]
+        }
+    )
+
+    podcast_downloader.run()
+
+    cover_path = Path(podcast_directory.path()) / "cover.png"
+    assert cover_path.read_bytes() == b"itunes-cover"
+    podcast_directory.is_containing_only(["cover.png"])

--- a/podcast_downloader/__main__.py
+++ b/podcast_downloader/__main__.py
@@ -15,6 +15,7 @@ from podcast_downloader.configuration import (
     get_n_age_date,
     parse_day_label,
 )
+from .cover import download_podcast_cover
 from .utils import ConsoleOutputFormatter, compose
 from .downloaded import (
     get_downloaded_files,
@@ -209,6 +210,7 @@ if __name__ == "__main__":
         configuration.CONFIG_HTTP_HEADER: {"User-Agent": "podcast-downloader"},
         configuration.CONFIG_FILL_UP_GAPS: False,
         configuration.CONFIG_DOWNLOAD_DELAY: 0,
+        configuration.CONFIG_DOWNLOAD_PODCAST_COVER: False,
         configuration.CONFIG_LAST_RUN_MARK_PATH: None,
         configuration.CONFIG_PODCASTS: [],
     }
@@ -272,6 +274,10 @@ if __name__ == "__main__":
             CONFIGURATION[configuration.CONFIG_DOWNLOAD_DELAY],
             rss_source.get(configuration.CONFIG_DOWNLOAD_DELAY, 0),
         )
+        rss_download_podcast_cover = rss_source.get(
+            configuration.CONFIG_DOWNLOAD_PODCAST_COVER,
+            CONFIGURATION[configuration.CONFIG_DOWNLOAD_PODCAST_COVER],
+        )
 
         if rss_disable:
             logger.info('Skipping the "%s"', rss_source_name or rss_source_link)
@@ -288,6 +294,18 @@ if __name__ == "__main__":
             rss_source_name = get_feed_title_from_feed(feed)
 
         logger.info('Checking "%s"', rss_source_name)
+
+        if rss_download_podcast_cover:
+            try:
+                cover_path = download_podcast_cover(rss_https_header, rss_source_path, feed)
+                if cover_path:
+                    logger.info(
+                        '%s: Downloaded podcast cover as "%s"',
+                        rss_source_name,
+                        os.path.basename(cover_path),
+                    )
+            except Exception:
+                logger.exception('%s: Podcast cover could not be downloaded', rss_source_name)
 
         to_name_function = configuration_to_function_rss_to_name(
             rss_file_name_template_value, rss_source

--- a/podcast_downloader/configuration.py
+++ b/podcast_downloader/configuration.py
@@ -12,6 +12,7 @@ CONFIG_PODCAST_EXTENSIONS = "podcast_extensions"
 CONFIG_HTTP_HEADER = "http_headers"
 CONFIG_FILL_UP_GAPS = "fill_up_gaps"
 CONFIG_DOWNLOAD_DELAY = "download_delay"
+CONFIG_DOWNLOAD_PODCAST_COVER = "download_podcast_cover"
 CONFIG_LAST_RUN_MARK_PATH = "last_run_mark_file_path"
 
 CONFIG_PODCASTS = "podcasts"

--- a/podcast_downloader/cover.py
+++ b/podcast_downloader/cover.py
@@ -1,0 +1,88 @@
+import os
+import urllib.request
+from typing import Dict, Optional
+from urllib.parse import urlsplit
+
+
+COVER_FILE_NAME = "cover"
+COVER_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif")
+COVER_DOWNLOAD_CHUNK_SIZE = 64 * 1024
+CONTENT_TYPE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/pjpeg": ".jpg",
+    "image/png": ".png",
+    "image/x-png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/avif": ".avif",
+}
+
+
+def get_podcast_cover_url(feed) -> Optional[str]:
+    image = feed.feed.get("image", {})
+    return image.get("href") if image else None
+
+
+def get_podcast_cover_extension(
+    image_url: str, content_type: Optional[str] = None
+) -> Optional[str]:
+    extension = os.path.splitext(urlsplit(image_url).path)[1].lower()
+    if extension in COVER_EXTENSIONS:
+        return extension
+
+    if content_type:
+        return CONTENT_TYPE_EXTENSIONS.get(content_type.split(";", 1)[0].strip().lower())
+
+    return None
+
+
+def find_existing_podcast_cover(path: str) -> Optional[str]:
+    prefix = COVER_FILE_NAME + "."
+
+    for file_name in os.listdir(path):
+        if not file_name.startswith(prefix) or file_name.endswith(".part"):
+            continue
+
+        cover_path = os.path.join(path, file_name)
+        if os.path.isfile(cover_path):
+            return cover_path
+
+    return None
+
+
+def download_podcast_cover(headers: Dict[str, str], path: str, feed) -> Optional[str]:
+    existing_cover = find_existing_podcast_cover(path)
+    if existing_cover:
+        return None
+
+    image_url = get_podcast_cover_url(feed)
+    if not image_url:
+        return None
+
+    request = urllib.request.Request(image_url, headers=headers)
+    with urllib.request.urlopen(request) as response:
+        content_type = response.headers.get("Content-Type")
+        extension = get_podcast_cover_extension(image_url, content_type)
+        if not extension:
+            return None
+
+        cover_path = os.path.join(path, COVER_FILE_NAME + extension)
+        temporary_cover_path = cover_path + ".part"
+
+        try:
+            with open(temporary_cover_path, "wb") as cover_file:
+                while True:
+                    chunk = response.read(COVER_DOWNLOAD_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    cover_file.write(chunk)
+            os.replace(temporary_cover_path, cover_path)
+        except Exception:
+            try:
+                os.remove(temporary_cover_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    return cover_path

--- a/tests/podcast_cover_test.py
+++ b/tests/podcast_cover_test.py
@@ -1,0 +1,123 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import feedparser
+
+from podcast_downloader.cover import (
+    COVER_DOWNLOAD_CHUNK_SIZE,
+    download_podcast_cover,
+    find_existing_podcast_cover,
+    get_podcast_cover_extension,
+    get_podcast_cover_url,
+)
+
+
+class PodcastCoverTest(unittest.TestCase):
+    def test_get_cover_url_from_feed_image(self):
+        feed = feedparser.FeedParserDict(
+            feed=feedparser.FeedParserDict(
+                image=feedparser.FeedParserDict(href="https://example.com/cover.jpg")
+            )
+        )
+
+        self.assertEqual(
+            "https://example.com/cover.jpg", get_podcast_cover_url(feed)
+        )
+
+    def test_get_cover_extension_ignores_query_string(self):
+        self.assertEqual(
+            ".jpg",
+            get_podcast_cover_extension(
+                "https://example.com/cover.jpg?width=1500&height=1500"
+            ),
+        )
+
+    def test_get_cover_extension_uses_content_type_when_url_has_no_extension(self):
+        self.assertEqual(
+            ".png",
+            get_podcast_cover_extension(
+                "https://example.com/artwork", "image/png; charset=binary"
+            ),
+        )
+
+    def test_get_cover_extension_accepts_common_content_type_aliases(self):
+        aliases = {
+            "image/jpg": ".jpg",
+            "image/pjpeg": ".jpg",
+            "image/x-png": ".png",
+        }
+
+        for content_type, expected_extension in aliases.items():
+            with self.subTest(content_type=content_type):
+                self.assertEqual(
+                    expected_extension,
+                    get_podcast_cover_extension(
+                        "https://example.com/artwork", content_type
+                    ),
+                )
+
+    def test_existing_cover_is_detected_regardless_of_extension(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cover_path = os.path.join(directory, "cover.bmp")
+            with open(cover_path, "wb") as cover_file:
+                cover_file.write(b"cover")
+
+            self.assertEqual(cover_path, find_existing_podcast_cover(directory))
+
+    def test_partial_cover_is_not_treated_as_existing_cover(self):
+        with tempfile.TemporaryDirectory() as directory:
+            partial_cover_path = os.path.join(directory, "cover.jpg.part")
+            with open(partial_cover_path, "wb") as cover_file:
+                cover_file.write(b"partial")
+
+            self.assertIsNone(find_existing_podcast_cover(directory))
+
+    @patch("podcast_downloader.cover.urllib.request.urlopen")
+    def test_cover_is_streamed_to_disk_in_chunks(self, urlopen):
+        response = MagicMock()
+        response.headers.get.return_value = "image/jpeg"
+        response.read.side_effect = [b"first", b"second", b""]
+        urlopen.return_value.__enter__.return_value = response
+
+        feed = feedparser.FeedParserDict(
+            feed=feedparser.FeedParserDict(
+                image=feedparser.FeedParserDict(href="https://example.com/cover.jpg")
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            cover_path = download_podcast_cover({}, directory, feed)
+
+            with open(cover_path, "rb") as cover_file:
+                self.assertEqual(b"firstsecond", cover_file.read())
+
+            self.assertEqual(
+                [call(COVER_DOWNLOAD_CHUNK_SIZE)] * 3,
+                response.read.call_args_list,
+            )
+
+    @patch("podcast_downloader.cover.urllib.request.urlopen")
+    def test_failed_download_does_not_leave_partial_cover(self, urlopen):
+        response = MagicMock()
+        response.headers.get.return_value = "image/jpeg"
+        response.read.side_effect = OSError("connection interrupted")
+        urlopen.return_value.__enter__.return_value = response
+
+        feed = feedparser.FeedParserDict(
+            feed=feedparser.FeedParserDict(
+                image=feedparser.FeedParserDict(href="https://example.com/cover.jpg")
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(OSError):
+                download_podcast_cover({}, directory, feed)
+
+            self.assertIsNone(find_existing_podcast_cover(directory))
+            self.assertFalse(os.path.exists(os.path.join(directory, "cover.jpg.part")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an optional way to download the main podcast cover directly from artwork already exposed by the RSS feed.

The new `download_podcast_cover` option is disabled by default, so existing behavior is unchanged. It can be enabled globally or per podcast.

When enabled, it:

* uses channel-level RSS artwork (`<image>` / `<itunes:image>` as parsed by feedparser);
* saves the image as `cover.<ext>` in the podcast directory;
* supports common image formats including JPEG, PNG, GIF, WebP and AVIF;
* falls back to the response `Content-Type` when the image URL has no useful extension;
* reuses the configured `http_headers`;
* skips the download when a `cover.*` file already exists;
* writes through a temporary `.part` file so interrupted downloads do not leave a broken cover behind;
* does not prevent episode processing if the cover download fails.

Example:

```json
{
  "download_podcast_cover": true,
  "podcasts": [
    {
      "rss_link": "https://example.com/feed.xml",
      "path": "~/podcasts/example"
    }
  ]
}
```

Tested with:

* `python -m unittest discover -s tests -p "*_test.py"` — 43 passed
* `pytest e2e` — 24 passed

Fixes #78
